### PR TITLE
Add missing `template` keyword

### DIFF
--- a/llvm/include/llvm/ADT/PointerSumType.h
+++ b/llvm/include/llvm/ADT/PointerSumType.h
@@ -272,11 +272,11 @@ struct DenseMapInfo<PointerSumType<TagT, MemberTs...>> {
   using SomePointerInfo = DenseMapInfo<SomePointerT>;
 
   static inline SumType getEmptyKey() {
-    return SumType::create<SomeTag>(SomePointerInfo::getEmptyKey());
+    return SumType::template create<SomeTag>(SomePointerInfo::getEmptyKey());
   }
 
   static inline SumType getTombstoneKey() {
-    return SumType::create<SomeTag>(SomePointerInfo::getTombstoneKey());
+    return SumType::template create<SomeTag>(SomePointerInfo::getTombstoneKey());
   }
 
   static unsigned getHashValue(const SumType &Arg) {


### PR DESCRIPTION
This fixes compile warnings that break the openasip self-test (`expected ‘template’ keyword before dependent template name`)